### PR TITLE
ci: github workflow: Bump Ubuntu version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - ubuntu-20.04
+          - ubuntu-24.04
         compiler:
           # The NetSurf build system can't find LLVM AR (it looks for it
           # in /usr/lib instead of /usr/bin:


### PR DESCRIPTION
Ubuntu 20.04 is not available any more.