### PR TITLE
desktop: textarea: Unsigned difference expression compared to zero

### DIFF
--- a/desktop/textarea.c
+++ b/desktop/textarea.c
@@ -1087,7 +1087,7 @@ static bool textarea_reflow_multiline(struct textarea *ta,
 
 				continue;
 
-			} else if (len - b_off > 0) {
+			} else if (b_off < len) {
 				/* soft wrapped, find last space (if any) */
 				for (space = text + b_off; space > text;
 						space--) {


### PR DESCRIPTION
Squash CodeQL `cpp/unsigned-difference-expression-compared-zero` issue.

    This rule finds relational comparisons between the result of
    an unsigned subtraction and the value `0`. Such comparisons
    are likely to be wrong as the value of an unsigned subtraction
    can never be negative. So the relational comparison ends up
    checking whether the result of the subtraction is equal to 0.
    This is probably not what the programmer intended.