### PR TITLE
amiga: bound copy of printer unit name

### DIFF
--- a/frontends/amiga/print.c
+++ b/frontends/amiga/print.c
@@ -217,8 +217,9 @@ static BOOL ami_print_readunit(CONST_STRPTR filename, char name[],
 										case ID_PDEV:
 											if (ReadChunkBytes(iff, &pdev, sizeof(pdev)) == sizeof(pdev))
 											{
-												if (pdev.pd_UnitName[0])
-													strcpy(name,pdev.pd_UnitName);
+												if (pdev.pd_UnitName[0]) {
+													strlcpy(name, pdev.pd_UnitName, namesize);
+												}
 											}
 											break;
 										default:


### PR DESCRIPTION
- Respect the namesize parameter in ami_print_readunit() when copying pdev.pd_UnitName.
- Avoid potential buffer overflow by replacing strcpy with bounded strlcpy.