### PR TITLE
amiga: bound copy of ASL drawer path

### DIFF
--- a/frontends/amiga/file.c
+++ b/frontends/amiga/file.c
@@ -63,7 +63,7 @@ HOOKF(ULONG, ami_file_asl_mime_hook, struct FileRequester *, fr, struct AnchorPa
 
 	if(msg->ap_Info.fib_DirEntryType > 0) return(TRUE);
 
-	strcpy(fname,fr->fr_Drawer);
+	strlcpy(fname, fr->fr_Drawer, sizeof(fname));
 	AddPart(fname, msg->ap_Info.fib_FileName,1024);
 
   	mt = strdup(fetch_filetype(fname));


### PR DESCRIPTION
- Avoid potential buffer overflow in ami_file_asl_mime_hook() when copying fr_Drawer into a fixed 1024-byte buffer.
- Replace strcpy with bounded strlcpy.