### PR TITLE
amiga: respect hide_docky_icon when registering app from Shell

### DIFF
--- a/frontends/amiga/gui.c
+++ b/frontends/amiga/gui.c
@@ -1592,11 +1592,15 @@ static void gui_init2(int argc, char** argv)
 		}
 		else
 		{
-/* TODO: Specify icon when run from Shell */
+			ULONG noicon = TAG_IGNORE;
+
+			if (nsoption_bool(hide_docky_icon))
+				noicon = REGAPP_NoIcon;
+
 			ami_appid = RegisterApplication(messages_get("NetSurf"),
 				REGAPP_URLIdentifier, "netsurf-browser.org",
 				REGAPP_FileName, argv[0],
-				REGAPP_NoIcon, TRUE,
+				noicon, TRUE,
 				REGAPP_HasPrefsWindow, TRUE,
 				REGAPP_CanCreateNewDocs, TRUE,
 				REGAPP_UniqueApplication, TRUE,


### PR DESCRIPTION
- Avoid forcing REGAPP_NoIcon when started from Shell.
- Use the same hide_docky_icon logic as the WBStartup path.