### PR TITLE
amiga: do not force plugin placeholder to 0x0 on open

### DIFF
--- a/frontends/amiga/plugin_hack.c
+++ b/frontends/amiga/plugin_hack.c
@@ -194,9 +194,7 @@ nserror amiga_plugin_hack_open(struct content *c, struct browser_window *bw,
 
 	if(c)
 	{
-		/* TODO: Do we need valid dimensions at this point? */
-		c->width = 0;
-		c->height = 0;
+		/* Width/height will be set via reformat(); do not force 0x0 here. */
 	}
 
 	return NSERROR_OK;


### PR DESCRIPTION
- Avoid forcing plugin placeholder content dimensions to 0×0 in amiga_plugin_hack_open().
- Dimensions are set by amiga_plugin_hack_reformat(); leaving them unchanged avoids layout edge cases.