### PR TITLE
amiga: use snprintf for screenmode id strings

### DIFF
--- a/frontends/amiga/gui.c
+++ b/frontends/amiga/gui.c
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdio.h>
 
 #ifdef __amigaos4__
 /* Custom StringView class */
@@ -1222,7 +1223,7 @@ static void ami_openscreen(void)
 				{
 					char *modeid = malloc(20);
 					id = screenmodereq->sm_DisplayID;
-					sprintf(modeid, "0x%lx", id);
+					snprintf(modeid, 20, "0x%lx", id);
 					nsoption_set_charp(screen_modeid, modeid);
 					ami_nsoption_write();
 				}

--- a/frontends/amiga/gui_options.c
+++ b/frontends/amiga/gui_options.c
@@ -19,6 +19,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #include <proto/exec.h>
 #include <proto/graphics.h>
@@ -1860,7 +1861,7 @@ static void ami_gui_opts_use(bool save)
 	if(id)
 	{
 		char *modeid = malloc(20);
-		sprintf(modeid,"0x%lx", id);
+		snprintf(modeid, 20, "0x%lx", id);
 		nsoption_set_charp(screen_modeid, modeid);
 	}
 


### PR DESCRIPTION
Replace sprintf with bounded snprintf when formatting screen_modeid strings in GUI and options.