### PR TITLE
amiga: make ami_locate_resource size-aware

### DIFF
--- a/frontends/amiga/gui.h
+++ b/frontends/amiga/gui.h
@@ -19,6 +19,7 @@
 #ifndef AMIGA_GUI_H
 #define AMIGA_GUI_H
 
+#include <stddef.h>
 #include <stdbool.h>
 #include <graphics/rastport.h>
 #include <intuition/classusr.h>
@@ -94,7 +95,7 @@ BOOL ami_gadget_hit(Object *obj, int x, int y);
 void ami_gui_history(struct gui_window_2 *gwin, bool back);
 void ami_gui_hotlist_update_all(void);
 void ami_gui_tabs_toggle_all(void);
-bool ami_locate_resource(char *fullpath, const char *file);
+bool ami_locate_resource(char *fullpath, size_t fullpath_size, const char *file);
 void ami_gui_update_hotlist_button(struct gui_window_2 *gwin);
 nserror ami_gui_new_blank_tab(struct gui_window_2 *gwin);
 int ami_gui_count_windows(int window, int *tabs);

--- a/frontends/amiga/menu.c
+++ b/frontends/amiga/menu.c
@@ -143,7 +143,7 @@ void ami_menu_alloc_item(struct ami_menu_data **md, int num, UBYTE type,
 
 	if(LIB_IS_AT_LEAST((struct Library *)GadToolsBase, 53, 7)) {
 		if(icon) {
-			if(ami_locate_resource(menu_icon, icon) == true) {
+			if(ami_locate_resource(menu_icon, sizeof(menu_icon), icon) == true) {
 				md[num]->menuicon = (char *)strdup(menu_icon);
 			} else {
 				/* If the requested icon can't be found, put blank space in instead */


### PR DESCRIPTION
- Add an explicit output buffer size to ami_locate_resource().
- Use bounded copies and pass the correct size through to path building.
- Update all call sites to pass sizeof(buffer).